### PR TITLE
Ticket #9: Make it compatible with Rubygems 2.5 / Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 rvm:
   - 2.1.2
+  - 2.3.1
 
 language: ruby
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 0.2.1 (Next)
 
-* Your contribution here.
+* [#10](https://github.com/dblock/gem-licenses/pull/10): Rename class in order to avoid conflict with Rubygems 2.5 - [@caiosba](https://github.com/caiosba)
 
 #### 0.2.0 (7/17/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 0.2.1 (Next)
 
-* [#10](https://github.com/dblock/gem-licenses/pull/10): Rename class in order to avoid conflict with Rubygems 2.5 - [@caiosba](https://github.com/caiosba)
+* Your contribution here.
+* [#10](https://github.com/dblock/gem-licenses/pull/10): Rename class (from `Gem::Licenses` to `Gem::GemLicenses`) in order to avoid conflict with Rubygems 2.5 - [@caiosba](https://github.com/caiosba).
 
 #### 0.2.0 (7/17/2015)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 Install Rake tasks from Rakefile.
 
 ```
-Gem::Licenses.install_tasks
+Gem::GemLicenses.install_tasks
 ```
 
 To list licenses try the following Rake task.

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,4 @@ require 'rake'
 Bundler::GemHelper.install_tasks
 
 require 'gem_licenses'
-Gem::Licenses.install_tasks
+Gem::GemLicenses.install_tasks

--- a/gem-licenses.gemspec
+++ b/gem-licenses.gemspec
@@ -3,7 +3,7 @@ require 'gem-licenses/version'
 
 Gem::Specification.new do |s|
   s.name = 'gem-licenses'
-  s.version = Gem::Licenses::VERSION
+  s.version = Gem::GemLicenses::VERSION
   s.authors = ['Daniel Doubrovkine']
   s.email = 'dblock@dblock.org'
   s.platform = Gem::Platform::RUBY

--- a/lib/gem-licenses/install_tasks.rb
+++ b/lib/gem-licenses/install_tasks.rb
@@ -1,5 +1,5 @@
 module Gem
-  module Licenses
+  module GemLicenses
     def self.install_tasks
       spec = Gem::Specification.find_by_name('gem-licenses')
       Dir[File.join(spec.gem_dir, 'tasks/*.rake')].each do |file|

--- a/lib/gem-licenses/version.rb
+++ b/lib/gem-licenses/version.rb
@@ -1,5 +1,5 @@
 module Gem
-  module Licenses
+  module GemLicenses
     VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
I basically rename `Gem::Licenses` to `Gem::GemLicenses` (could be anything) in order to avoid a conflict with the `Gem::Licenses` defined by Rubygems 2.5. Closes  #9.