### PR TITLE
Make order of rake gem:licenses deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 0.2.2 (Next)
 
 * Your contribution here.
+* [#18](https://github.com/dblock/gem-licenses/pull/18): Make order of rake gem:licenses deterministic - [@edennis](https://github.com/edennis).
 
 #### 0.2.1 (5/31/2016)
 

--- a/tasks/licenses.rake
+++ b/tasks/licenses.rake
@@ -1,7 +1,7 @@
 desc 'Gather open-source licenses.'
 namespace :gem do
   task :licenses do
-    Gem.licenses.each do |license, gems|
+    Gem.licenses.sort_by { |k, v| [-v.count, k] }.each do |license, gems|
       puts license.to_s
       puts '=' * license.length
       gems.sort_by(&:name).each do |gem|


### PR DESCRIPTION
Hey there! First of all, thanks for publishing these rake tasks as a gem. It's been very useful for maintaining an overview of what software our project is using. In fact, we found it so useful that we've added them to our CI build to automatically check when new dependencies were added or removed and to notify us when this happens. Basically, what we've done is created a list of the licenses by running:
```
rake gem:licenses > LICENSES.md
```
And we've added a check to travis that does a diff between the version-controlled `LICENSES.md` and the current output of the rake task:
```
rake gem:licenses | diff -bu LICENSES.md -
```
The problem is that the order of the list isn't stable so we sometimes get false alarms. This PR addresses that and also adds an optional argument to the rake task to choose between alphabetical sorting of the list by license name or by the license count (default).