### PR TITLE
Load Tasks vs Install Tasks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -42,6 +42,6 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-    - 'lib/gem-licenses/install_tasks.rb'
+    - 'lib/gem-licenses/load_tasks.rb'
     - 'lib/gem/licenses.rb'
     - 'lib/gem/specification.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 0.2.3 (Next)
 
-* Your contribution here.
+* Load Rake tasks via `Gem::Licenses.load_tasks` - [@dblock](https://github.com/dblock).
 
 #### 0.2.2 (2/16/2018)
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ group :development, :test do
 end
 ```
 
-Install Rake tasks from Rakefile.
+Load Rake tasks in your Rakefile.
 
 ```ruby
 require 'gem-licenses'
-Gem::GemLicenses.install_tasks
+Gem::GemLicenses.load_tasks
 ```
 
 To list licenses try the following Rake task.

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,4 @@ require 'rake'
 Bundler::GemHelper.install_tasks
 
 require 'gem_licenses'
-Gem::GemLicenses.install_tasks
+Gem::GemLicenses.load_tasks

--- a/lib/gem-licenses/load_tasks.rb
+++ b/lib/gem-licenses/load_tasks.rb
@@ -1,6 +1,10 @@
 module Gem
   module GemLicenses
     def self.install_tasks
+      load_tasks
+    end
+
+    def self.load_tasks
       spec = Gem::Specification.find_by_name('gem-licenses')
       Dir[File.join(spec.gem_dir, 'tasks/*.rake')].each do |file|
         load file

--- a/lib/gem_licenses.rb
+++ b/lib/gem_licenses.rb
@@ -1,5 +1,5 @@
 require 'yaml'
 require 'gem-licenses/version'
-require 'gem-licenses/install_tasks'
+require 'gem-licenses/load_tasks'
 require 'gem/specification'
 require 'gem/licenses'


### PR DESCRIPTION
Can I recommend changing `load_tasks` to `load_tasks` to follow a pattern set by Rails?

To my chagrin, it wasn't clear to me immediately that I needed to place this line in the Rakefile. I realize the Readme (sorta) mentions it, but we could clean that up with "Load rake tasks by calling `Gem::GemLicenses.load_tasks` in a `Rakefile`.

`install_tasks` leaves me with the assumption I only need to do it once. I thought perhaps it would copy the `.rake` files over to my project directory.

I feel silly, but finally figured it out. The intent here would be to prevent someone else from spinning their wheels on this. I started down the rabbit hole of finding a version or rake that was compatible because it kept throwing an error about that. And _before_ that, I'd opened a ticket (sorry) about rake not being loaded.

I know this is a bit nuanced and maybe somewhat subjective, but I figured instead of opening a ticket I'd just do the work to slick the skids. Your gem, your call. Give it some thought!

Cheers!

P.S. Thanks for writing `gem-licenses`! :)
